### PR TITLE
Update to 2017.3.35488 & Change Directory Creation

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,9 +2,9 @@ default['java']['install_flavor'] = 'oracle'
 default['java']['jdk_version'] = '8'
 default['java']['oracle']['accept_oracle_download_terms'] = true
 
-default['cookbook_youtrack']['youtrack']['version'] = '2017.2.34480'
+default['cookbook_youtrack']['youtrack']['version'] = '2017.3.35488'
 default['cookbook_youtrack']['youtrack']['install_root_dir'] = '/opt/youtrack'
 default['cookbook_youtrack']['youtrack']['data_dir'] = '/root/.YoutrackData'
 default['cookbook_youtrack']['youtrack']['backup_dir'] = '/root/.YoutrackBackup'
-default['cookbook_youtrack']['youtrack']['download_url'] = 'https://download.jetbrains.com/charisma/youtrack-2017.2.34480.zip'
+default['cookbook_youtrack']['youtrack']['download_url'] = 'https://download.jetbrains.com/charisma/youtrack-2017.3.35488.zip'
 default['cookbook_youtrack']['youtrack']['memory_options'] = '-Xmx1g'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'fred.thompson@buildempire.co.uk'
 license          'Apache 2.0'
 description      'TeamCity and YouTrack on one server.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.12'
+version          '0.1.13'
 
 recipe 'cookbook_youtrack', 'YouTrack instance.'
 

--- a/recipes/youtrack.rb
+++ b/recipes/youtrack.rb
@@ -28,17 +28,6 @@ directory install_root_dir do
   action :create
 end
 
-# Create the youtrack version directory
-directory install_dir do
-  recursive true
-  action :create
-end
-
-# Set the symbolic link to the current installation
-link current_dir do
-  to install_dir
-end
-
 # Create the data directory
 directory data_directory do
   recursive true
@@ -62,7 +51,13 @@ end
 # Run the commands to extract and move youtrack into place.
 bash "extract-youtrack" do
   code <<-EOH
-    unzip #{youtrack_archive_path} -d #{install_dir}
+    unzip #{youtrack_archive_path} -d #{install_root_dir}
   EOH
   action :nothing
+end
+
+
+# Set the symbolic link to the new installation
+link current_dir do
+  to install_dir
 end


### PR DESCRIPTION
Modified the extraction of the files so that we extract into the correct place. 

Currently extracting `youtrack-2017.3.35488.zip` to `/opt/youtrack/2017.3.35488` would actually result in the files being put in `/opt/youtrack/2017.3.35488/2017.3.35488` which was wrong. 

This would then mean I'd have to manually move the files up a directory. 

The symlink creation is moved to the end to ensure that the directory exists that we're looking to create. 